### PR TITLE
apply BC to adjoint equation rhs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate fenicsproject
+          conda install -c conda-forge pip
           python -m pip install --upgrade pip
           pip install --upgrade pip setuptools==65.7.0
           python -m pip install cuqipy --pre

--- a/cuqipy_fenics/pde.py
+++ b/cuqipy_fenics/pde.py
@@ -481,6 +481,9 @@ class SteadyStateLinearFEniCSPDE(FEniCSPDE):
                 "Gradient wrt parameter for PDE with observation operator not implemented")
 
         adjoint_rhs = -direction.vector()
+        # Apply the adjoint boundary conditions to the adjoint rhs
+        for bc in self._adjoint_dirichlet_bcs:
+            bc.apply(adjoint_rhs)
         dl.solve(adjoint_matrix, adjoint.vector(), adjoint_rhs)
 
         # Compute gradient

--- a/tests/test_PDEModel.py
+++ b/tests/test_PDEModel.py
@@ -452,18 +452,17 @@ def test_gradient_poisson():
     )
 
     # Create a likelihood
-    y = cuqi.distribution.Gaussian(
-        mean=PDE_model(m_prior), cov=np.ones(PDE_model.range_dim)*.1**2, geometry=PDE_model.range_geometry)
-    y = y(y=PDE_model(m.vector().get_local()))
+    datadist = cuqi.distribution.Gaussian(
+        mean=PDE_model(m_prior), cov=np.ones(PDE_model.range_dim)*.02**2, geometry=PDE_model.range_geometry)
+    data = datadist(m_prior = m.vector().get_local()).sample()
+    y = datadist(datadist=data)
 
-    # Evaluate the adjoint based gradient at value m2
-    m2 = dl.Function(poisson.parameter_function_space)
-    m2.vector()[:] = np.random.randn(PDE_model.domain_dim)
-    adjoint_grad = y.gradient(m_prior=m2.vector().get_local())
+    # Evaluate the adjoint based gradient at value m
+    adjoint_grad = y.gradient(m_prior=m.vector().get_local())
 
     # Compute the FD gradient
     step = 1e-7   # finite diff step
-    FD_grad = optimize.approx_fprime(m2.vector().get_local(), y.logd, step)
+    FD_grad = optimize.approx_fprime(m.vector().get_local(), y.logd, step)
 
     # Check that the adjoint gradient and FD gradient are close
     assert np.allclose(adjoint_grad, FD_grad, rtol=1e-1),\


### PR DESCRIPTION
closes #101 

Note regarding tests:
---------------------

The current gradient tests (before this PR) pass regardless of this update. So as part of this PR, the parameters of one of the tests (`test_gradient_poisson`) were updated so that the test fails when the adjoint BC are not applied correctly. 

Finite difference vs adjoint based gradient before the fix:
<img width="554" height="413" alt="image" src="https://github.com/user-attachments/assets/59229af2-7ede-4d22-85c1-08adfbc8de24" />

Finite difference vs adjoint based gradient after the fix:
<img width="559" height="413" alt="image" src="https://github.com/user-attachments/assets/d0ca79cc-421b-4e5b-9502-4065a5a9cda8" />


Note regarding documentation:
-------------------------------
The documentation build failed initially for this PR. So a one-line fix was added to the file `docs.yml`.